### PR TITLE
Update #2 #86bw7m38d - Load new core_external external classes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,10 @@ input, bug reports and beta testing
 
 * Author: Luuk Verhoeven, [MFreak.nl](https://MFreak.nl/)
 * Author: Gemma Lesterhuis, [Lesterhuis Training & Consultancy](https://ltnc.nl/)
-* Min. required: Moodle 3.5.x
-* Supports PHP:  7.2
+* Min. required: Moodle 4.2
+* Supports PHP:  7.4
 
-![Moodle35](https://img.shields.io/badge/moodle-3.5-brightgreen.svg)
-![Moodle36](https://img.shields.io/badge/moodle-3.6-brightgreen.svg)
-![Moodle37](https://img.shields.io/badge/moodle-3.7-brightgreen.svg)
-![Moodle38](https://img.shields.io/badge/moodle-3.8-brightgreen.svg)
-![Moodle39](https://img.shields.io/badge/moodle-3.9-brightgreen.svg)
-![Moodle310](https://img.shields.io/badge/moodle-3.10-brightgreen.svg)
-![Moodle400](https://img.shields.io/badge/moodle-4.0-brightgreen.svg)
-![Moodle401](https://img.shields.io/badge/moodle-4.1-brightgreen.svg)
+![Moodle402](https://img.shields.io/badge/moodle-4.2-brightgreen.svg)
 
 ## Screens
 
@@ -40,6 +33,14 @@ input, bug reports and beta testing
 2. Login as administrator
 3. Go to Site Administrator > Notification
 4. Install the plugin
+
+
+### Changelog
+
+##### 4.2 (27-10-2023)
+* Updated external_api namespace loading from core_external.
+* No longer backwards compatible.
+
 
 ## Security
 

--- a/classes/external.php
+++ b/classes/external.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * External libary
+ * External library
  *
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
@@ -28,11 +28,12 @@ namespace block_user_favorites;
 
 use block_user_favorites\output\output_favorites;
 use context_block;
+use context_user;
 use dml_exception;
-use external_api;
-use external_function_parameters;
-use external_single_structure;
-use external_value;
+use core_external\external_api;
+use core_external\external_function_parameters;
+use core_external\external_single_structure;
+use core_external\external_value;
 use moodle_exception;
 use required_capability_exception;
 

--- a/version.php
+++ b/version.php
@@ -26,8 +26,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2023091300;
+$plugin->version = 2023102700;
 $plugin->requires = 2017111300;
 $plugin->component = 'block_user_favorites';
-$plugin->release = '4.1.3';
+$plugin->release = '4.2.0';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
@gemguardian Here are the modifications needed for Moodle 4.2. Note that these updates are incompatible with previous versions. Can you validate this is working like expected?